### PR TITLE
un-ignore the numbers tag for Wiki Education Dashboard

### DIFF
--- a/groups/Wikimedia/WikiEduDashboard.yaml
+++ b/groups/Wikimedia/WikiEduDashboard.yaml
@@ -34,7 +34,7 @@ AUTOLOAD:
 
 TAGS:
   ignored:
-    - wikiedudashboard-number.*
+    - wikiedudashboard-number.human.decimal_units.units.unit
     - wikiedudashboard-article.views_added
     - wikiedudasbhoard-tasks.*
     - wikiedudashboard-timeout


### PR DESCRIPTION
See https://phabricator.wikimedia.org/T204722

The Dashboard uses these very short unit abbreviations for displaying large numbers in a relatively constrained space, but Rails falls back to the default versions which are fully spelled out (and in English). The blank 'unit' label can be ignored, but the others should be translatable.